### PR TITLE
録音停止ボタンが機能しない問題を修正

### DIFF
--- a/frontend/src/components/Transcript.jsx
+++ b/frontend/src/components/Transcript.jsx
@@ -109,13 +109,12 @@ function Transcript({ transcript, setTranscript, meetingId, isRecording, setIsRe
       <div style={{ marginBottom: '20px' }}>
         {isSupported ? (
           <>
-            <button
-              onClick={isRecording ? stopRecording : startRecording}
-              className={`btn ${isRecording ? 'danger' : 'success'}`}
-              disabled={isRecording}
-            >
-              {isRecording ? '🔴 録音中...' : '🎤 音声入力開始'}
-            </button>
+              <button
+                onClick={isRecording ? stopRecording : startRecording}
+                className={`btn ${isRecording ? 'danger' : 'success'}`}
+              >
+                {isRecording ? '⏹️ 録音停止' : '🎤 音声入力開始'}
+              </button>
             <button onClick={addManualText} className="btn">
               ✏️ 手動追加
             </button>


### PR DESCRIPTION
## 概要
- 録音中に停止ボタンが無効化されていた問題を解消
- 録音中は「⏹️ 録音停止」ボタンを表示するように変更

## テスト
- `npm test` (スクリプト未定義)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68929de17b688321977da4f8a9f870d2